### PR TITLE
i elements inside Button now inherit font size from Button and are vertically aligned in the middle

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -4,6 +4,11 @@
   border: 0;
   border-radius: 3px;
   cursor: pointer;
+
+  i {
+    font-size: inherit;
+    vertical-align: middle;
+  }
 }
 
 .isAddonRight {


### PR DESCRIPTION
Some font icons CSS apply styling rules directly to their `<i/>` elements, which caused the font icon to render in a different font-size from the Button's font-size.
