### PR TITLE
Only manage font-size o i element inside Button

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -7,7 +7,6 @@
 
   i {
     font-size: inherit;
-    vertical-align: middle;
   }
 }
 


### PR DESCRIPTION
Too intrusive to enforce `vertical-align` of `<i/>` elements inside `Button`.
